### PR TITLE
Add filebeat config to automatically parse k8s json logs

### DIFF
--- a/filebeat.docker.yml
+++ b/filebeat.docker.yml
@@ -2,6 +2,8 @@ filebeat.inputs:
 - type: log
   enabled: true
   paths:
-    - /tmp/host-logs/kube-apiserver-audit.log 
+    - /tmp/host-logs/kube-apiserver-audit.log
+  json.keys_under_root: false
+  json.add_error_key: true
 output.elasticsearch:
   hosts: 'elasticsearch:9200'


### PR DESCRIPTION
Added a tiny config change so the json k8s logs are automatically parsed. 

This is the resulting log in Elasticsearch with the change. 

> {
>   "_index": "filebeat-7.7.0-2020.05.30-000001",
>   "_type": "_doc",
>   "_id": "0rl_Z3IBNFCjqUFrGItT",
>   "_version": 1,
>   "_score": null,
>   "_source": {
>     "@timestamp": "2020-05-30T21:31:21.065Z",
>     "log": {
>       "offset": 5324227,
>       "file": {
>         "path": "/tmp/host-logs/kube-apiserver-audit.log"
>       }
>     },
>     "json": {
>       "verb": "get",
>       "userAgent": "kube-controller-manager/v1.18.2 (linux/amd64) kubernetes/b5cdb79/leader-election",
>       "requestReceivedTimestamp": "2020-05-30T21:31:19.693324Z",
>       "kind": "Event",
>       "stageTimestamp": "2020-05-30T21:31:19.695775Z",
>       "sourceIPs": [
>         "127.0.0.1"
>       ],
>       "objectRef": {
>         "resource": "leases",
>         "namespace": "kube-system",
>         "name": "kube-controller-manager",
>         "apiGroup": "coordination.k8s.io",
>         "apiVersion": "v1"
>       },
>       "responseStatus": {
>         "metadata": {},
>         "code": 200
>       },
>       "stage": "ResponseComplete",
>       "level": "Metadata",
>       "user": {
>         "username": "system:kube-controller-manager",
>         "uid": "controller",
>         "groups": [
>           "system:authenticated"
>         ]
>       },
>       "auditID": "ea06833c-e10c-41e3-9d88-8e9ccad53431",
>       "requestURI": "/apis/coordination.k8s.io/v1/namespaces/kube-system/leases/kube-controller-manager?timeout=10s",
>       "apiVersion": "audit.k8s.io/v1",
>       "annotations": {
>         "authorization.k8s.io/decision": "allow",
>         "authorization.k8s.io/reason": ""
>       }
>     },
>     "input": {
>       "type": "log"
>     },
>     "ecs": {
>       "version": "1.5.0"
>     },
>     "host": {
>       "name": "d9a3e8062fac"
>     },
>     "agent": {
>       "id": "28179303-ff0e-4139-94f8-2840e3d62f98",
>       "version": "7.7.0",
>       "type": "filebeat",
>       "ephemeral_id": "6a1eebff-9be6-488c-ae78-3d339ef025fd",
>       "hostname": "d9a3e8062fac"
>     }
>   },
>   "fields": {
>     "suricata.eve.timestamp": [
>       "2020-05-30T21:31:21.065Z"
>     ],
>     "@timestamp": [
>       "2020-05-30T21:31:21.065Z"
>     ]
>   },
>   "sort": [
>     1590874281065
>   ]
> }